### PR TITLE
Update the API usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,22 @@ Read the built documentation by opening:
 
 Import the library and try some commands:
 
-    ```python
-    $ python
-    >>> import todoist
-    >>> api = todoist.TodoistAPI()
-    >>> user = api.login('john.doe@gmail.com', 'secret')
-    >>> print(user['full_name'])
-    John Doe
-    >>> response = api.sync(resource_types=['all'])
-    >>> for project in response['Projects']:
-            print(project['name'])
-    Personal
-    Shopping
-    Work
-    Errands
-    Movies to watch
-    ```
+```python
+$ python
+>>> import todoist
+>>> api = todoist.TodoistAPI()
+>>> user = api.login('john.doe@gmail.com', 'secret')
+>>> print(user['full_name'])
+John Doe
+>>> response = api.sync(resource_types=['all'])
+>>> for project in response['Projects']:
+        print(project['name'])
+Personal
+Shopping
+Work
+Errands
+Movies to watch
+```
 
 
 ## Testing the library

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ $ python
 John Doe
 >>> response = api.sync(resource_types=['all'])
 >>> for project in response['Projects']:
-        print(project['name'])
+...     print(project['name'])
+...
 Personal
 Shopping
 Work

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements:
 
 Clone the repo:
 
-    $ git clone git@github.com:Doist/todoist-python.git 
+    $ git clone git@github.com:Doist/todoist-python.git
 
 Create an environment:
 
@@ -41,16 +41,22 @@ Read the built documentation by opening:
 
 Import the library and try some commands:
 
+    ```python
     $ python
-    [...]
     >>> import todoist
     >>> api = todoist.TodoistAPI()
-    >>> api.login('me', 'secret')
-    [...]
-    >>> api.ping('mytoken')
-    [...]
-    >>> api.get()
-    [...]
+    >>> user = api.login('john.doe@gmail.com', 'secret')
+    >>> print(user['full_name'])
+    John Doe
+    >>> response = api.sync(resource_types=['all'])
+    >>> for project in response['Projects']:
+            print(project['name'])
+    Personal
+    Shopping
+    Work
+    Errands
+    Movies to watch
+    ```
 
 
 ## Testing the library


### PR DESCRIPTION
The methods `ping()` and `get()` were removed from the API as part of this commit https://github.com/Doist/todoist-python/commit/66fbeb673cbc6c00aba08d3bc6e88e137ed7b09f. However, the code example in `README.md` was never updated to reflect these changes.

This is a small change to update the example.

Associated Issue #8.