### PR TITLE
Removed deprecated 'message' param.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='todoist-python',
-    version='7.0.18',
+    version='7.0.19',
     packages=['todoist', 'todoist.managers'],
     author='Doist Team',
     author_email='info@todoist.com',

--- a/todoist/managers/projects.py
+++ b/todoist/managers/projects.py
@@ -94,7 +94,7 @@ class ProjectsManager(Manager, AllMixin, GetByIdMixin, SyncMixin):
         }
         self.queue.append(cmd)
 
-    def share(self, project_id, email, message=''):
+    def share(self, project_id, email):
         """
         Shares a project with a user.
         """

--- a/todoist/models.py
+++ b/todoist/models.py
@@ -223,11 +223,11 @@ class Project(Model):
         self.api.projects.unarchive(self['id'])
         self.data['is_archived'] = 0
 
-    def share(self, email, message=''):
+    def share(self, email):
         """
         Shares projects with a user.
         """
-        self.api.projects.share(self['id'], email, message)
+        self.api.projects.share(self['id'], email)
 
     def take_ownership(self):
         """


### PR DESCRIPTION
This removes the `message` parameter inside of the `ProjectsManager` as it is no longer used. 

As this has not been used in v7 (and this not used in production), the library is bumped to minor version 7.0.19.

Closes [#42](https://github.com/Doist/todoist-python/issues/42)