### PR TITLE
Encrypt cached data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     long_description = read('README.md'),
     install_requires=[
         'requests',
+        'cryptography'
     ],
     # see here for complete list of classifiers
     # http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='todoist-python',
-    version='7.0.18',
+    version='7.0.19',
     packages=['todoist', 'todoist.managers'],
     author='Doist Team',
     author_email='info@todoist.com',

--- a/todoist/managers/projects.py
+++ b/todoist/managers/projects.py
@@ -94,7 +94,7 @@ class ProjectsManager(Manager, AllMixin, GetByIdMixin, SyncMixin):
         }
         self.queue.append(cmd)
 
-    def share(self, project_id, email, message=''):
+    def share(self, project_id, email):
         """
         Shares a project with a user.
         """

--- a/todoist/models.py
+++ b/todoist/models.py
@@ -223,11 +223,11 @@ class Project(Model):
         self.api.projects.unarchive(self['id'])
         self.data['is_archived'] = 0
 
-    def share(self, email, message=''):
+    def share(self, email):
         """
         Shares projects with a user.
         """
-        self.api.projects.share(self['id'], email, message)
+        self.api.projects.share(self['id'], email)
 
     def take_ownership(self):
         """


### PR DESCRIPTION
Sync data was not being encrypted when cached on the file system at ~/.todoist_sync. This PR adds the `cryptography` library and uses `fernet` to encrypt/decrypt sync data.

Closes [#38](https://github.com/Doist/todoist-python/issues/38) and uses [#41](https://github.com/Doist/todoist-python/pull/41) as references.