### PR TITLE
Bound typing package to python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     license="BSD",
     description="todoist-python - The official Todoist Python API library",
     long_description=read("README.md"),
-    install_requires=["requests", "typing"],
+    install_requires=[
+        "requests", 
+        "typing;python_version<3.5",
+    ],
     # see here for complete list of classifiers
     # http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=(

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description=read("README.md"),
     install_requires=[
         "requests", 
-        "typing;python_version<3.5",
+        "typing;python_version<'3.5'",
     ],
     # see here for complete list of classifiers
     # http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
It was added to the stdlib in 3.5, and can cause issues in rare cases when included.

https://www.python.org/dev/peps/pep-0484/