### PR TITLE
Use a dict for internal state

### DIFF
--- a/todoist/managers/generic.py
+++ b/todoist/managers/generic.py
@@ -24,7 +24,7 @@ class Manager(object):
 
 class AllMixin(object):
     def all(self, filt=None):
-        return list(filter(filt, self.state[self.state_name]))
+        return list(filter(filt, self.state[self.state_name].values()))
 
 
 class GetByIdMixin(object):
@@ -32,17 +32,23 @@ class GetByIdMixin(object):
         """
         Finds and returns the object based on its id.
         """
-        for obj in self.state[self.state_name]:
-            if obj["id"] == obj_id or obj.temp_id == str(obj_id):
+        if str(obj_id) in self.state[self.state_name]:
+            return self.state[self.state_name][str(obj_id)]
+
+        for _, obj in self.state[self.state_name].items():
+            if obj.temp_id == str(obj_id):
                 return obj
 
         if not only_local and self.object_type is not None:
             getter = getattr(eval("self.api.%ss" % self.object_type), "get")
             data = getter(obj_id)
 
+            if str(obj_id) in self.state[self.state_name]:
+                return self.state[self.state_name]
+
             # retrieves from state, otherwise we return the raw data
-            for obj in self.state[self.state_name]:
-                if obj["id"] == obj_id or obj.temp_id == str(obj_id):
+            for _, obj in self.state[self.state_name].items():
+                if obj.temp_id == str(obj_id):
                     return obj
 
             return data

--- a/todoist/managers/items.py
+++ b/todoist/managers/items.py
@@ -182,6 +182,9 @@ class ItemsManager(Manager, AllMixin, GetByIdMixin, SyncMixin):
         """
         Gets an existing item.
         """
+        if str(item_id) in self.api.state['items']:
+            return {"item": self.api.state['items'][str(item_id)].data}
+
         params = {"token": self.token, "item_id": item_id}
         obj = self.api._get("items/get", params=params)
         if obj and "error" in obj:

--- a/todoist/managers/labels.py
+++ b/todoist/managers/labels.py
@@ -64,6 +64,9 @@ class LabelsManager(Manager, AllMixin, GetByIdMixin, SyncMixin):
         """
         Gets an existing label.
         """
+        if str(label_id) in self.api.state['labels']:
+            return {"label": self.api.state['labels'][str(label_id)].data}
+
         params = {"token": self.token, "label_id": label_id}
         obj = self.api._get("labels/get", params=params)
         if obj and "error" in obj:


### PR DESCRIPTION
* This speeds up retrieval inside the local cache as it's now possible
  to do a O(1) lookup in the cache rather than having to do an API call
  whenever `.get(id)` is called.

* This is potentially a breaking change: while I didn't encounter any
  incompatibilities, the local fs state needs to be recreated entirely.

* For a proof-of-concept I only added the optimization to `labels` and
  `items` for now. However the change can be applied to any other
  manager as well.